### PR TITLE
[v1.2] Updated CLI Syntax and ParserUtil

### DIFF
--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -12,4 +12,11 @@ public class CliSyntax {
     public static final Prefix PREFIX_ADDRESS = new Prefix("a/");
     public static final Prefix PREFIX_TAG = new Prefix("t/");
 
+    /* Prefix definitions for NASA */
+    public static final Prefix PREFIX_MODULE = new Prefix("m/");
+    public static final Prefix PREFIX_DATE = new Prefix("d/");
+    public static final Prefix PREFIX_ACTIVITY_NAME = new Prefix("a/");
+    public static final Prefix PREFIX_PRIORITY = new Prefix("p/");
+    public static final Prefix PREFIX_MODULE_NAME = new Prefix("n/");
+    public static final Prefix PREFIX_NOTE = new Prefix("n/");
 }

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -9,11 +9,15 @@ import java.util.Set;
 import seedu.address.commons.core.index.Index;
 import seedu.address.commons.util.StringUtil;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.activity.Date;
+import seedu.address.model.activity.Name;
+import seedu.address.model.activity.Note;
+import seedu.address.model.activity.Priority;
 import seedu.address.model.person.Address;
 import seedu.address.model.person.Email;
-import seedu.address.model.person.Name;
 import seedu.address.model.person.Phone;
 import seedu.address.model.tag.Tag;
+
 
 /**
  * Contains utility methods used for parsing strings in the various *Parser classes.
@@ -41,13 +45,13 @@ public class ParserUtil {
      *
      * @throws ParseException if the given {@code name} is invalid.
      */
-    public static Name parseName(String name) throws ParseException {
+    public static seedu.address.model.person.Name parseName(String name) throws ParseException {
         requireNonNull(name);
         String trimmedName = name.trim();
-        if (!Name.isValidName(trimmedName)) {
+        if (!seedu.address.model.person.Name.isValidName(trimmedName)) {
             throw new ParseException(Name.MESSAGE_CONSTRAINTS);
         }
-        return new Name(trimmedName);
+        return new seedu.address.model.person.Name(trimmedName);
     }
 
     /**
@@ -121,4 +125,69 @@ public class ParserUtil {
         }
         return tagSet;
     }
+
+    /**
+     * Parses {@code String date} into a {@code Date}.
+     * Checks if the string date is of valid form.
+     * @param date of the user input
+     * @return Date object created based on user input
+     * @throws ParseException
+     */
+    public static Date parseDate(String date) throws ParseException {
+        requireNonNull(date);
+        String dateTrimmed = date.trim();
+        if (!Date.isValidDate(dateTrimmed)) {
+            throw new ParseException(Date.MESSAGE_CONSTRAINTS);
+        }
+        return new Date(dateTrimmed);
+    }
+
+    /**
+     * Parses {@code String name} into a {@code Name}.
+     * Checks if the String name is not empty or does not only consists of whitespaces.
+     * @param name of the activity
+     * @return Name object of the activity
+     * @throws ParseException
+     */
+    public static Name parseActivityName(String name) throws ParseException {
+        requireNonNull(name);
+        String nameTrimmed = name.trim();
+        if (!Name.isValidName(nameTrimmed)) {
+            throw new ParseException(Name.MESSAGE_CONSTRAINTS);
+        }
+        return new Name(nameTrimmed);
+    }
+
+    /**
+     * Parses {@code String note} into a {@code Note}
+     * Checks if the String note isn't empty or doesn't only contain whitespaces.
+     * @param note of the activity
+     * @return Note object of the activity
+     * @throws ParseException
+     */
+    public static Note parseNote(String note) throws ParseException {
+        requireNonNull(note);
+        String noteTrimmed = note.trim();
+        if (!Note.isValidNote(noteTrimmed)) {
+            throw new ParseException(Note.MESSAGE_CONSTRAINTS);
+        }
+        return new Note(noteTrimmed);
+    }
+
+    /**
+     * Parses {@code String priority} into a {@code Priority}
+     * Checks if the String priority is a correct integer.
+     * @param priority of the activity
+     * @return Priority object of the activity
+     * @throws ParseException
+     */
+    public static Priority parsePriority(String priority) throws ParseException {
+        requireNonNull(priority);
+        String priorityTrimmed = priority.trim();
+        if (!Priority.isValidPriorityValue(priorityTrimmed)) {
+            throw new ParseException(Priority.PRIORITY_RANGE_CONSTRAINTS);
+        }
+        return new Priority(priorityTrimmed);
+    }
+
 }

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -14,6 +14,9 @@ import java.util.Set;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.activity.Date;
+import seedu.address.model.activity.Note;
+import seedu.address.model.activity.Priority;
 import seedu.address.model.person.Address;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;
@@ -35,6 +38,17 @@ public class ParserUtilTest {
     private static final String VALID_TAG_2 = "neighbour";
 
     private static final String WHITESPACE = " \t\r\n";
+
+    private static final String VALID_DATE = "2020-08-20";
+    private static final String VALID_ACTIVITY_NAME = "CS2103T TP";
+    private static final String VALID_NOTE = "Finish milestone v1.2 by next wednesday."
+            + "prepare for new features.";
+    private static final String VALID_PRIORITY = "3";
+
+    private static final String INVALID_DATE = "20-12-2020";
+    private static final String INVALID_ACTIVITY_NAME = " ";
+    private static final String INVALID_NOTE = "\t\r";
+    private static final String INVALID_PRIORITY = "-2";
 
     @Test
     public void parseIndex_invalidInput_throwsParseException() {
@@ -192,5 +206,101 @@ public class ParserUtilTest {
         Set<Tag> expectedTagSet = new HashSet<Tag>(Arrays.asList(new Tag(VALID_TAG_1), new Tag(VALID_TAG_2)));
 
         assertEquals(expectedTagSet, actualTagSet);
+    }
+
+    @Test
+    public void parseDate_validDateWithoutWhitespaces_returnsDate() throws Exception {
+        Date expectedDate = new Date(VALID_DATE);
+        assertEquals(expectedDate, ParserUtil.parseDate(VALID_DATE));
+    }
+
+    @Test
+    public void parseDate_validDateWithWhitespaces_returnsDate() throws Exception {
+        String dateWithWhiteSpace = WHITESPACE + VALID_DATE + WHITESPACE;
+        Date expectedDate = new Date(VALID_DATE);
+        assertEquals(expectedDate, ParserUtil.parseDate(dateWithWhiteSpace));
+    }
+
+    @Test
+    public void parseDate_invalidDateWithoutWhitespaces_throwsParseException() {
+        assertThrows(ParseException.class, () -> ParserUtil.parseDate(INVALID_DATE));
+    }
+
+    @Test
+    public void parseDate_invalidDateWithWhitespaces_throwsParseException() {
+        String dateWithWhiteSpace = WHITESPACE + INVALID_DATE + WHITESPACE;
+        assertThrows(ParseException.class, () -> ParserUtil.parseDate(dateWithWhiteSpace));
+    }
+
+    @Test
+    public void parseActivityName_validNameWithoutWhitespaces_returnsName() throws Exception {
+        seedu.address.model.activity.Name expectedName = new seedu.address.model.activity.Name(VALID_NAME);
+        assertEquals(expectedName, ParserUtil.parseActivityName(VALID_NAME));
+    }
+
+    @Test
+    public void parseActivityName_validNameWithWhitespaces_returnsName() throws Exception {
+        String nameWithWhiteSpaces = WHITESPACE + VALID_ACTIVITY_NAME + WHITESPACE;
+        seedu.address.model.activity.Name expectedName = new seedu.address.model.activity.Name(VALID_ACTIVITY_NAME);
+        assertEquals(expectedName, ParserUtil.parseActivityName(nameWithWhiteSpaces));
+    }
+
+    @Test
+    public void parseActivityName_invalidNameWithoutWhitespaces_throwsParseException() {
+        assertThrows(ParseException.class, () -> ParserUtil.parseActivityName(INVALID_ACTIVITY_NAME));
+    }
+
+    @Test
+    public void parseActivityName_invalidNameWithWhitespaces_throwsParseException() {
+        String nameWithWhiteSpaces = WHITESPACE + INVALID_ACTIVITY_NAME + WHITESPACE;
+        assertThrows(ParseException.class, () -> ParserUtil.parseActivityName(nameWithWhiteSpaces));
+    }
+
+    @Test
+    public void parseNote_validNoteWithoutWhitespaces_returnsNote() throws Exception {
+        Note expectedNote = new Note(VALID_NOTE);
+        assertEquals(expectedNote, ParserUtil.parseNote(VALID_NOTE));
+    }
+
+    @Test
+    public void parseNote_validNoteWithWhitespaces_returnsNote() throws Exception {
+        String noteWithWhiteSpaces = WHITESPACE + VALID_NOTE + WHITESPACE;
+        Note expectedNote = new Note(VALID_NOTE);
+        assertEquals(expectedNote, ParserUtil.parseNote(noteWithWhiteSpaces));
+    }
+
+    @Test
+    public void parseNote_invalidNoteWithoutWhitespaces_throwsParseException() {
+        assertThrows(ParseException.class, () -> ParserUtil.parseNote(INVALID_NOTE));
+    }
+
+    @Test
+    public void parseNote_invalidNoteWithWhitespaces_throwsParseException() {
+        String noteWithWhiteSpaces = WHITESPACE + INVALID_NOTE + WHITESPACE;
+        assertThrows(ParseException.class, () -> ParserUtil.parseNote(noteWithWhiteSpaces));
+    }
+
+    @Test
+    public void parsePriority_validPriorityWithoutWhiteSpaces_returnsPriority() throws Exception {
+        Priority expectedPriority = new Priority(VALID_PRIORITY);
+        assertEquals(expectedPriority, ParserUtil.parsePriority(VALID_PRIORITY));
+    }
+
+    @Test
+    public void parsePriority_validPriorityWithWhiteSpaces_returnsPriority() throws Exception {
+        String priorityWithWhitespaces = WHITESPACE + VALID_PRIORITY + WHITESPACE;
+        Priority expectedPriority = new Priority(VALID_PRIORITY);
+        assertEquals(expectedPriority, ParserUtil.parsePriority(priorityWithWhitespaces));
+    }
+
+    @Test
+    public void parsePriority_invalidPriorityWithoutWhiteSpaces_throwsParseException() {
+        assertThrows(ParseException.class, () -> ParserUtil.parsePriority(INVALID_PRIORITY));
+    }
+
+    @Test
+    public void parsePriority_invalidPriorityWithWhiteSpaces_throwsParseException() {
+        String priorityWithWhitespaces = WHITESPACE + INVALID_PRIORITY + WHITESPACE;
+        assertThrows(ParseException.class, () -> ParserUtil.parsePriority(priorityWithWhitespaces));
     }
 }

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -281,25 +281,25 @@ public class ParserUtilTest {
     }
 
     @Test
-    public void parsePriority_validPriorityWithoutWhiteSpaces_returnsPriority() throws Exception {
+    public void parsePriority_validPriorityWithoutWhitespaces_returnsPriority() throws Exception {
         Priority expectedPriority = new Priority(VALID_PRIORITY);
         assertEquals(expectedPriority, ParserUtil.parsePriority(VALID_PRIORITY));
     }
 
     @Test
-    public void parsePriority_validPriorityWithWhiteSpaces_returnsPriority() throws Exception {
+    public void parsePriority_validPriorityWithWhitespaces_returnsPriority() throws Exception {
         String priorityWithWhitespaces = WHITESPACE + VALID_PRIORITY + WHITESPACE;
         Priority expectedPriority = new Priority(VALID_PRIORITY);
         assertEquals(expectedPriority, ParserUtil.parsePriority(priorityWithWhitespaces));
     }
 
     @Test
-    public void parsePriority_invalidPriorityWithoutWhiteSpaces_throwsParseException() {
+    public void parsePriority_invalidPriorityWithoutWhitespaces_throwsParseException() {
         assertThrows(ParseException.class, () -> ParserUtil.parsePriority(INVALID_PRIORITY));
     }
 
     @Test
-    public void parsePriority_invalidPriorityWithWhiteSpaces_throwsParseException() {
+    public void parsePriority_invalidPriorityWithWhitespaces_throwsParseException() {
         String priorityWithWhitespaces = WHITESPACE + INVALID_PRIORITY + WHITESPACE;
         assertThrows(ParseException.class, () -> ParserUtil.parsePriority(priorityWithWhitespaces));
     }


### PR DESCRIPTION
- Updated CLI Syntax with the command scheme that we agreed upon
- Updated ParserUtil to allow us to Parse date, notes, priority and name class for activity models.


@don-tay 
For priority, you also need to handle the input cannot be parsed as an integer. For now, the JUNIT tests i did ignored that, but please implement and update the JUNIT test to include that. Thanks.

@CharmaineKoh 
For date object, I think LocalDateTime is more appropriate than LocalDate as the time for activities are also important. Just need to change to LocalDateTime for the date class. And update the JUNIT test that I have done. Currently it only tests LocalDate. Need to change that.
Also for name object, the regex expression used is incorrect. The regex expressions is used for people names where only characters and spaces (of course no empty string or strings with only whitespaces). But it does not allow numbers. So names such as "Assignment 1" cannot be created for activity names. Change the regex expression and I think you are good to go. Thanks.