### PR TITLE
Fixed modulecode and activity name being case sensitive

### DIFF
--- a/src/main/java/nasa/model/activity/Name.java
+++ b/src/main/java/nasa/model/activity/Name.java
@@ -48,7 +48,7 @@ public class Name {
     public boolean equals(Object other) {
         return other == this // short circuit if same object
                 || (other instanceof Name // instanceof handles nulls
-                && name.equals(((Name) other).name)); // state check
+                && name.toLowerCase().equals(((Name) other).name.toLowerCase())); // state check
     }
 
     @Override

--- a/src/main/java/nasa/model/activity/UniqueActivityList.java
+++ b/src/main/java/nasa/model/activity/UniqueActivityList.java
@@ -37,7 +37,7 @@ public class UniqueActivityList implements Iterable<Activity> {
      */
     public boolean contains(Activity toCheck) {
         requireNonNull(toCheck);
-        return internalList.stream().anyMatch(toCheck::isSameActivity);
+        return internalList.stream().anyMatch(toCheck::equals);
     }
 
     /**
@@ -192,7 +192,7 @@ public class UniqueActivityList implements Iterable<Activity> {
     private boolean activitiesAreUnique(List<Activity> activities) {
         for (int i = 0; i < activities.size() - 1; i++) {
             for (int j = i + 1; j < activities.size(); j++) {
-                if (activities.get(i).isSameActivity(activities.get(j))) {
+                if (activities.get(i).equals(activities.get(j))) {
                     return false;
                 }
             }

--- a/src/main/java/nasa/model/module/ModuleCode.java
+++ b/src/main/java/nasa/model/module/ModuleCode.java
@@ -48,7 +48,8 @@ public class ModuleCode {
     public boolean equals(Object other) {
         return other == this // short circuit if same object
                 || (other instanceof ModuleCode // instanceof handles nulls
-                && moduleCode.equals(((ModuleCode) other).moduleCode)); // state check
+                && moduleCode.toLowerCase().equals(((ModuleCode) other)
+            .moduleCode.toLowerCase())); // state check
     }
 
     @Override


### PR DESCRIPTION
- Adding modules had to be case sensitive, if CS2030, must type cs2030, fixed the bug by making the equals method compare lowercase strings
- Same goes to activities, in addition, activity names that are the same (case insensitive) will be counted as duplicate activities